### PR TITLE
Add styles for nav using circles as specified in style guide. Images can be replaced.

### DIFF
--- a/docassemble/HousingCodeChecklist/data/static/active.svg
+++ b/docassemble/HousingCodeChecklist/data/static/active.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="68.141998"
+   height="100"
+   viewBox="0 0 18.029237 26.458334"
+   version="1.1"
+   id="svg5"
+   sodipodi:docname="active.svg"
+   inkscape:version="1.1 (c4e8f9e, 2021-05-24)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="3.6102266"
+     inkscape:cx="-6.2322958"
+     inkscape:cy="36.285811"
+     inkscape:window-width="1312"
+     inkscape:window-height="826"
+     inkscape:window-x="128"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     units="px"
+     width="68.142px" />
+  <defs
+     id="defs2">
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter7716"
+       x="-0.208674"
+       y="-0.20867402"
+       width="1.417348"
+       height="1.417348">
+      <feFlood
+         flood-opacity="1"
+         flood-color="rgb(0,123,255)"
+         result="flood"
+         id="feFlood7706" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite7708" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1"
+         result="blur"
+         id="feGaussianBlur7710" />
+      <feOffset
+         dx="0"
+         dy="0"
+         result="offset"
+         id="feOffset7712" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite7714" />
+    </filter>
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-49.962738,-70.936493)">
+    <rect
+       style="fill:none;fill-opacity:0.0309734;stroke:none;stroke-width:1.08736;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1973"
+       width="13.229167"
+       height="26.458334"
+       x="52.362774"
+       y="70.936493" />
+    <ellipse
+       style="fill:#007bff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.508814;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter7716)"
+       id="path31"
+       cx="58.977356"
+       cy="84.165657"
+       rx="6.3601766"
+       ry="6.3601761" />
+    <circle
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.491369;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6900"
+       cx="58.977356"
+       cy="84.165657"
+       r="2.4882522" />
+  </g>
+</svg>

--- a/docassemble/HousingCodeChecklist/data/static/active_first_item.svg
+++ b/docassemble/HousingCodeChecklist/data/static/active_first_item.svg
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="68.141998"
+   height="100"
+   viewBox="0 0 18.029238 26.458334"
+   version="1.1"
+   id="svg5"
+   sodipodi:docname="active_first_item.svg"
+   inkscape:version="1.1 (c4e8f9e, 2021-05-24)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="3.5803196"
+     inkscape:cx="1.5361757"
+     inkscape:cy="46.923186"
+     inkscape:window-width="1312"
+     inkscape:window-height="826"
+     inkscape:window-x="128"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     units="px" />
+  <defs
+     id="defs2">
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter7716"
+       x="-0.208674"
+       y="-0.20867402"
+       width="1.417348"
+       height="1.417348">
+      <feFlood
+         flood-opacity="1"
+         flood-color="rgb(0,123,255)"
+         result="flood"
+         id="feFlood7706" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite7708" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1"
+         result="blur"
+         id="feGaussianBlur7710" />
+      <feOffset
+         dx="0"
+         dy="0"
+         result="offset"
+         id="feOffset7712" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite7714" />
+    </filter>
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-49.962738,-70.936493)">
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.02266;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2263"
+       width="18.029238"
+       height="13.229167"
+       x="49.962738"
+       y="70.936493" />
+    <rect
+       style="fill:none;fill-opacity:0.0309734;stroke:none;stroke-width:1.08736;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1973"
+       width="13.229167"
+       height="26.458334"
+       x="52.362774"
+       y="70.936493" />
+    <ellipse
+       style="fill:#007bff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.508814;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter7716)"
+       id="path31"
+       cx="58.977356"
+       cy="84.165657"
+       rx="6.3601766"
+       ry="6.3601761" />
+    <circle
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.491369;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6900"
+       cx="58.977356"
+       cy="84.165657"
+       r="2.4882522" />
+  </g>
+</svg>

--- a/docassemble/HousingCodeChecklist/data/static/active_last_item.svg
+++ b/docassemble/HousingCodeChecklist/data/static/active_last_item.svg
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="68.141998"
+   height="100"
+   viewBox="0 0 18.029238 26.458334"
+   version="1.1"
+   id="svg5"
+   sodipodi:docname="active_last_item.svg"
+   inkscape:version="1.1 (c4e8f9e, 2021-05-24)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="4.1469871"
+     inkscape:cx="7.3547371"
+     inkscape:cy="43.405006"
+     inkscape:window-width="1312"
+     inkscape:window-height="826"
+     inkscape:window-x="128"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     units="px" />
+  <defs
+     id="defs2">
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter7716"
+       x="-0.208674"
+       y="-0.20867402"
+       width="1.417348"
+       height="1.417348">
+      <feFlood
+         flood-opacity="1"
+         flood-color="rgb(0,123,255)"
+         result="flood"
+         id="feFlood7706" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite7708" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1"
+         result="blur"
+         id="feGaussianBlur7710" />
+      <feOffset
+         dx="0"
+         dy="0"
+         result="offset"
+         id="feOffset7712" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite7714" />
+    </filter>
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-49.962738,-70.936493)">
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.02266;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2263"
+       width="18.029238"
+       height="13.229167"
+       x="49.962738"
+       y="77.551079" />
+    <rect
+       style="fill:none;fill-opacity:0.0309734;stroke:none;stroke-width:1.08736;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1973"
+       width="13.229167"
+       height="26.458334"
+       x="52.362774"
+       y="70.936493" />
+    <ellipse
+       style="fill:#007bff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.508814;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter7716)"
+       id="path31"
+       cx="58.977356"
+       cy="84.165657"
+       rx="6.3601766"
+       ry="6.3601761" />
+    <circle
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.491369;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6900"
+       cx="58.977356"
+       cy="84.165657"
+       r="2.4882522" />
+  </g>
+</svg>

--- a/docassemble/HousingCodeChecklist/data/static/done.svg
+++ b/docassemble/HousingCodeChecklist/data/static/done.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="13.229167mm"
+   height="26.458334mm"
+   viewBox="0 0 13.229167 26.458334"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1 (c4e8f9e, 2021-05-24)"
+   sodipodi:docname="done.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="4.1469871"
+     inkscape:cx="17.482572"
+     inkscape:cy="37.617672"
+     inkscape:window-width="1312"
+     inkscape:window-height="826"
+     inkscape:window-x="123"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-49.962738,-70.936493)">
+    <rect
+       style="fill:none;fill-opacity:0.03097345;stroke:none;stroke-width:1.08736;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1973"
+       width="13.229167"
+       height="26.458334"
+       x="49.962738"
+       y="70.936493" />
+    <circle
+       style="fill:#007bff;fill-opacity:1;fill-rule:evenodd;stroke-width:0.0677653"
+       id="path31"
+       cx="56.577324"
+       cy="84.165657"
+       r="6.6145835" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#f6f6f6;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 52.4389,84.747546 3.049152,2.447183 5.227694,-6.058119"
+       id="path925"
+       sodipodi:nodetypes="ccc" />
+  </g>
+</svg>

--- a/docassemble/HousingCodeChecklist/data/static/done_first_item.svg
+++ b/docassemble/HousingCodeChecklist/data/static/done_first_item.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="13.229167mm"
+   height="26.458334mm"
+   viewBox="0 0 13.229167 26.458334"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1 (c4e8f9e, 2021-05-24)"
+   sodipodi:docname="done_first_item.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="4.1469871"
+     inkscape:cx="-30.021796"
+     inkscape:cy="37.617672"
+     inkscape:window-width="1312"
+     inkscape:window-height="826"
+     inkscape:window-x="50"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-49.962738,-70.936493)">
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.876008;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2263"
+       width="13.229167"
+       height="13.229167"
+       x="49.962738"
+       y="70.936493" />
+    <rect
+       style="fill:none;fill-opacity:0.03097345;stroke:none;stroke-width:1.08736;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1973"
+       width="13.229167"
+       height="26.458334"
+       x="49.962738"
+       y="70.936493" />
+    <circle
+       style="fill:#007bff;fill-opacity:1;fill-rule:evenodd;stroke-width:0.0677653"
+       id="path31"
+       cx="56.577324"
+       cy="84.165657"
+       r="6.6145835" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#f6f6f6;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 52.4389,84.747546 3.049152,2.447183 5.227694,-6.058119"
+       id="path925"
+       sodipodi:nodetypes="ccc" />
+  </g>
+</svg>

--- a/docassemble/HousingCodeChecklist/data/static/done_last_item.svg
+++ b/docassemble/HousingCodeChecklist/data/static/done_last_item.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="13.229167mm"
+   height="26.458334mm"
+   viewBox="0 0 13.229167 26.458334"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1 (c4e8f9e, 2021-05-24)"
+   sodipodi:docname="done_last_item.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="4.1469871"
+     inkscape:cx="17.482572"
+     inkscape:cy="37.617672"
+     inkscape:window-width="1312"
+     inkscape:window-height="826"
+     inkscape:window-x="123"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-49.962738,-70.936493)">
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.876008;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2263"
+       width="13.229167"
+       height="13.229167"
+       x="49.962738"
+       y="84.165657" />
+    <rect
+       style="fill:none;fill-opacity:0.03097345;stroke:none;stroke-width:1.08736;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1973"
+       width="13.229167"
+       height="26.458334"
+       x="49.962738"
+       y="70.936493" />
+    <circle
+       style="fill:#007bff;fill-opacity:1;fill-rule:evenodd;stroke-width:0.0677653"
+       id="path31"
+       cx="56.577324"
+       cy="84.165657"
+       r="6.6145835" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#f6f6f6;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 52.4389,84.747546 3.049152,2.447183 5.227694,-6.058119"
+       id="path925"
+       sodipodi:nodetypes="ccc" />
+  </g>
+</svg>

--- a/docassemble/HousingCodeChecklist/data/static/notavailableyet.svg
+++ b/docassemble/HousingCodeChecklist/data/static/notavailableyet.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="13.229167mm"
+   height="26.458334mm"
+   viewBox="0 0 13.229167 26.458334"
+   version="1.1"
+   id="svg5"
+   sodipodi:docname="notavailableyet.svg"
+   inkscape:version="1.1 (c4e8f9e, 2021-05-24)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="4.1469871"
+     inkscape:cx="17.482572"
+     inkscape:cy="37.617672"
+     inkscape:window-width="1312"
+     inkscape:window-height="826"
+     inkscape:window-x="123"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-49.962738,-70.936493)">
+    <rect
+       style="fill:none;fill-opacity:0.03097345;stroke:none;stroke-width:1.08736;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1973"
+       width="13.229167"
+       height="26.458334"
+       x="49.962738"
+       y="70.936493" />
+    <ellipse
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#cccccc;stroke-width:0.508814;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path31"
+       cx="56.57732"
+       cy="84.165657"
+       rx="6.3601766"
+       ry="6.3601761" />
+  </g>
+</svg>

--- a/docassemble/HousingCodeChecklist/data/static/notavailableyet_last_item.svg
+++ b/docassemble/HousingCodeChecklist/data/static/notavailableyet_last_item.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="13.229167mm"
+   height="26.458334mm"
+   viewBox="0 0 13.229167 26.458334"
+   version="1.1"
+   id="svg5"
+   sodipodi:docname="notavailableyet_last_item.svg"
+   inkscape:version="1.1 (c4e8f9e, 2021-05-24)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="4.1469871"
+     inkscape:cx="17.482572"
+     inkscape:cy="37.617672"
+     inkscape:window-width="1312"
+     inkscape:window-height="826"
+     inkscape:window-x="123"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-49.962738,-70.936493)">
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.876008;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2263"
+       width="13.229167"
+       height="13.229167"
+       x="49.962738"
+       y="84.165657" />
+    <rect
+       style="fill:none;fill-opacity:0.03097345;stroke:none;stroke-width:1.08736;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1973"
+       width="13.229167"
+       height="26.458334"
+       x="49.962738"
+       y="70.936493" />
+    <ellipse
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#cccccc;stroke-width:0.508814;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path31"
+       cx="56.57732"
+       cy="84.165657"
+       rx="6.3601766"
+       ry="6.3601761" />
+  </g>
+</svg>

--- a/docassemble/HousingCodeChecklist/data/static/styles.css
+++ b/docassemble/HousingCodeChecklist/data/static/styles.css
@@ -5,3 +5,96 @@
 .btn-secondary {
   min-width: 8em;
 }
+
+/* ========= Nav for interview sections ========= */
+
+/* === Nav item containers === */
+.danav-vertical.danavnested {
+  padding-left: 1em;
+}
+
+/* Vertical line for outer-most nav items */
+.danav-vertical:not(.danavnested) {
+  border-left: 2px solid #cccccc;
+  border-radius: 0;
+}
+
+/* === All nav items === */
+.danav-vertical .nav-link {
+  padding: .2em 1em;
+}
+
+.danav-vertical .danavlink::before {
+  content: '';
+  display: inline-block;
+  position: absolute;
+  /* The dimensions have to be bigger than the images of the circles, though it doesn't matter how much bigger. */
+  width: 1.5em;
+  /* This aligns well with the text while smaller heights don't. The images can be changed so that the we can decrease the circle sizes if we want. */
+  height: 2em;
+  /* Account for the border that creates the vertical line. */
+  left: -0.1em;
+  top: 0;
+  /* Translated relative to the pseudo-element itself. */
+  transform: translate(-50%, 0%);
+  /* Base the size on height, which is currently most consistently the same between different images. */
+  background-size: auto 100%;
+  /* This must be added because the dimensions of the pseudo-element don't exactly match the dimensions of the background element and we don't want to mess with those. Without this, the circle image would end up too far to the left. */
+  background-position: 50% 50%;
+  background-repeat: no-repeat;
+}
+
+/* === Nav item for currently active section === */
+/* `.active` nested nav items also seem to have `.daclickable` */
+.danav-vertical .danavlink.active::before,
+.danav-vertical .danavlink.daclickable.active::before {
+  background-image: url(active.svg);
+}
+.danav-vertical .danavlink.active:first-child:before,
+.danav-vertical .danavlink.daclickable.active:first-child:before {
+  /* Has extra white above the circle image to hide the border going through it. */
+  background-image: url(active_first_item.svg);
+}
+.danav-vertical .danavlink.active:last-child:before,
+.danav-vertical .danavlink.daclickable.active:last-child:before {
+  /* Has extra white below the circle image to hide the border going through it. */
+  background-image: url(active_last_item.svg);
+}
+
+/* Active item background and font colors */
+/* The color for an active item is now primay-colored text with no background. Should be handled with SCSS. Previous style was while text with primary-colored background. */
+.danav-vertical .nav-link.active,
+.danav-vertical .show > .nav-link {
+  background: none;
+  color: #007bff;
+}
+
+/* Hide the dropdown arrow for nested nav items. */
+/* This is not accessibility-friendly really because it doesn't have the aria-hidden attribute */
+.danav-vertical .danavlink .toggler {
+  display: none;
+}
+
+/* === Completed nav items (will all look clickable) === */
+.danav-vertical .danavlink::before {
+  background-image: url(done.svg);
+}
+.danav-vertical .danavlink:first-child:before {
+  /* Has extra white above the circle image to hide the border going through it. */
+  background-image: url(done_first_item.svg);
+}
+.danav-vertical .danavlink:last-child:before {
+  /* Has extra white below the circle image to hide the border going through it. */
+  background-image: url(done_last_item.svg);
+}
+
+/* === Nav items for sections that have not yet been visited. === */
+.danav-vertical .danavlink.danotavailableyet:before {
+  background-image: url(notavailableyet.svg);
+}
+/* First item never has this class */
+.danav-vertical .danavlink.danotavailableyet:last-child:before {
+  /* Has extra white below the circle image to hide the border going through it. */
+  background-image: url(notavailableyet_last_item.svg);
+}
+

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.HousingCodeChecklist',
       url='https://courtformsonline.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALMassachusetts>=0.0.7', 'docassemble.AssemblyLine>=2.3.3', 'docassemble.MAHousingTRO', 'docassemble.MassAccess>=0.0.3.1', 'docassemble.RentalRepairLetter', 'docassemble.SanitaryCode'],
+      install_requires=['docassemble.ALMassachusetts>=0.0.7', 'docassemble.AssemblyLine>=2.3.5', 'docassemble.MAHousingTRO', 'docassemble.MassAccess>=0.0.3.1', 'docassemble.RentalRepairLetter', 'docassemble.SanitaryCode'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/HousingCodeChecklist/', package='docassemble.HousingCodeChecklist'),
      )


### PR DESCRIPTION
If the images need to be made smaller, they will definitely have to be replaced to continue covering up the left-hand border. That can be pretty easily done, though, and should not need css adjustment other than to change the size itself. You would change the `height` property of the `:before` pseudo element.

Not sure if this addresses any particular issue.