### PR TITLE
Match page element font and circle sizes to nav sizes

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -369,6 +369,11 @@ css: |
     padding: 3px 8px;
     border-radius: 50%;
     }
+    
+    /* List number counter sizes to match circles in nav items (in styles.css). If one is adjusted, the other will have to be adjusted also. */
+    .custom-counter li::before {
+      padding: 0.5px 6.5px;
+    }
   </style>  
 
 ---

--- a/docassemble/HousingCodeChecklist/data/static/styles.css
+++ b/docassemble/HousingCodeChecklist/data/static/styles.css
@@ -6,8 +6,8 @@
   min-width: 8em;
 }
 
-/* Button sizes to match look of height of left-hand nav menu items */
-/* Font is left alone, which makes it a bit smaller. It's left alone because making the font bigger requires either a second linen for some buttons or making the horizontal padding smaller, which may look less polished */
+/* Playback button sizes to match look of height of left-hand nav menu items */
+/* Font is left alone and thus remains a bit smaller. */
 .media-action.btn {
   padding: 0.2em 0.75em;
 }

--- a/docassemble/HousingCodeChecklist/data/static/styles.css
+++ b/docassemble/HousingCodeChecklist/data/static/styles.css
@@ -6,6 +6,12 @@
   min-width: 8em;
 }
 
+/* Button sizes to match look of height of left-hand nav menu items */
+/* Font is left alone, which makes it a bit smaller. It's left alone because making the font bigger requires either a second linen for some buttons or making the horizontal padding smaller, which may look less polished */
+.btn-group-sm>.btn, .btn-sm {
+  padding: 0.2em 0.75em;
+}
+
 /* ========= Nav for interview sections ========= */
 
 /* === Nav item containers === */

--- a/docassemble/HousingCodeChecklist/data/static/styles.css
+++ b/docassemble/HousingCodeChecklist/data/static/styles.css
@@ -8,7 +8,7 @@
 
 /* Button sizes to match look of height of left-hand nav menu items */
 /* Font is left alone, which makes it a bit smaller. It's left alone because making the font bigger requires either a second linen for some buttons or making the horizontal padding smaller, which may look less polished */
-.btn-group-sm>.btn, .btn-sm {
+.media-action.btn {
   padding: 0.2em 0.75em;
 }
 


### PR DESCRIPTION
[New version, only playback button height is affected.] ~In this version, the heights of all small buttons will match the look of the nav heights, but we can make it specific to the playback button if that's desired. That's shown in the image below with the "I am being evicted" button.~ [Image removed]

<img width="961" alt="only_playback_matches" src="https://user-images.githubusercontent.com/52798256/133826553-9cf1bc66-1647-4074-99ac-00d372ab95c8.png">

<img width="789" alt="list_items_match" src="https://user-images.githubusercontent.com/52798256/133798530-0ec409e0-01e1-42ca-adb6-d17e58725961.png">

