### PR TITLE
Customize styles for problem selection buttons to match spec: smaller…

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -396,6 +396,8 @@ subquestion: |
 #  ${ collapse_template(sue_your_landlord_template) } 
 continue button field: learn_more
 ---  
+# WARNING: This page id needs to stay the same or the selectors for
+# the button styles in styles.css will need to be updated to match
 id: room chooser
 question: |
   Your landlord's responsibilities

--- a/docassemble/HousingCodeChecklist/data/static/styles.css
+++ b/docassemble/HousingCodeChecklist/data/static/styles.css
@@ -110,6 +110,13 @@
 /* ==================================== */
 /* ===== Problem category buttons ===== */
 /* WARNING: These styles are dependant on the page id being "room chooser" */
+
+/* To make up for the margin on the right that every element has
+* because the n-th child psuedo selector is not supported enough. */
+.question-room-chooser .da-field-buttons {
+  margin-right: -1em;
+}
+
 .question-room-chooser .btn-da-custom {
   /* The button style guide gives 15 extra pixels or so to the width
   * of the center column. These styles currently choose to make the
@@ -118,11 +125,13 @@
   /* position relative to anchor the position absolute angle bracket
   * on the right-hand side */
   position: relative;
-  width: 46%;
+  width: 47%;
   height: auto;
   margin-right: 0.7em;
   text-align: left;
   padding: 0.75rem 0.8em;
+  /* Maintain room for the right-hand side angle bracket */
+  padding-right: 1.8em;
   margin-bottom: 0.5em;
   border-radius: 3px;
   color: #6c757d;
@@ -137,20 +146,7 @@
   transform: translate(0, -50%);
 }
 
-/* Hide overflow text so buttons can stay one line high. The text
-* cannot be revealed. The user should never see this. It is meant
-* to be a hint to the developer that they need to shorten the text. */
-/* To work, this element must have an explicit width. */
-.question-room-chooser .btn-da-custom span {
-  width: 16em;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  display: inline-block;
-  /* To show arrow and have space for ellipsis */
-  padding-right: 1.2em;
-}
-
+/*  */
 .question-room-chooser .btn-da-custom span div {
   display: inline-block;
   margin-right: 0.6em;

--- a/docassemble/HousingCodeChecklist/data/static/styles.css
+++ b/docassemble/HousingCodeChecklist/data/static/styles.css
@@ -106,3 +106,59 @@
   background-image: url(notavailableyet_last_item.svg);
 }
 
+
+/* ==================================== */
+/* ===== Problem category buttons ===== */
+/* WARNING: These styles are dependant on the page id being "room chooser" */
+.question-room-chooser .btn-da-custom {
+  /* The button style guide gives 15 extra pixels or so to the width
+  * of the center column. These styles currently choose to make the
+  * text and all `em` styles slightly smaller instead. */
+  font-size: 0.9em;
+  /* position relative to anchor the position absolute angle bracket
+  * on the right-hand side */
+  position: relative;
+  width: 46%;
+  height: auto;
+  margin-right: 0.7em;
+  text-align: left;
+  padding: 0.75rem 0.8em;
+  margin-bottom: 0.5em;
+  border-radius: 3px;
+  color: #6c757d;
+}
+
+.question-room-chooser .btn-da-custom:after {
+  content: ">";
+  position: absolute;
+  top: 50%;
+  right: 1em;
+  font-weight: 700;
+  transform: translate(0, -50%);
+}
+
+/* Hide overflow text so buttons can stay one line high. The text
+* cannot be revealed. The user should never see this. It is meant
+* to be a hint to the developer that they need to shorten the text. */
+/* To work, this element must have an explicit width. */
+.question-room-chooser .btn-da-custom span {
+  width: 16em;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  display: inline-block;
+  /* To show arrow and have space for ellipsis */
+  padding-right: 1.2em;
+}
+
+.question-room-chooser .btn-da-custom span div {
+  display: inline-block;
+  margin-right: 0.6em;
+}
+
+.question-room-chooser .btn-da-custom svg {
+  height: 1em !important;
+  width: 1.5em !important;
+  vertical-align: middle;
+}
+

--- a/docassemble/HousingCodeChecklist/data/static/styles.css
+++ b/docassemble/HousingCodeChecklist/data/static/styles.css
@@ -125,7 +125,7 @@
   /* position relative to anchor the position absolute angle bracket
   * on the right-hand side */
   position: relative;
-  width: 47%;
+  width: 46%;
   height: auto;
   margin-right: 0.7em;
   text-align: left;

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.HousingCodeChecklist',
       url='https://courtformsonline.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALMassachusetts>=0.0.7', 'docassemble.AssemblyLine>=2.3.3', 'docassemble.MAHousingTRO', 'docassemble.MassAccess>=0.0.3.1', 'docassemble.RentalRepairLetter', 'docassemble.SanitaryCode'],
+      install_requires=['docassemble.ALMassachusetts>=0.0.7', 'docassemble.AssemblyLine>=2.3.5', 'docassemble.MAHousingTRO', 'docassemble.MassAccess>=0.0.3.1', 'docassemble.RentalRepairLetter', 'docassemble.SanitaryCode'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/HousingCodeChecklist/', package='docassemble.HousingCodeChecklist'),
      )


### PR DESCRIPTION
… image on same line as text, one-line, etc.

Not sure what issue this is associated with.