### PR TITLE
Close #183, improve section list styles

### DIFF
--- a/docassemble/HousingCodeChecklist/data/static/active_first_item_nested.svg
+++ b/docassemble/HousingCodeChecklist/data/static/active_first_item_nested.svg
@@ -2,12 +2,12 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="68.141998"
+   width="128"
    height="100"
-   viewBox="0 0 18.029238 26.458334"
+   viewBox="0 0 33.866668 26.458334"
    version="1.1"
    id="svg5"
-   sodipodi:docname="active_last_item.svg"
+   sodipodi:docname="active_first_item_nested.svg"
    inkscape:version="1.1 (c4e8f9e, 2021-05-24)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -21,15 +21,15 @@
      inkscape:pageshadow="2"
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
-     inkscape:document-units="mm"
+     inkscape:document-units="px"
      showgrid="false"
      fit-margin-top="0"
      fit-margin-left="0"
      fit-margin-right="0"
      fit-margin-bottom="0"
      inkscape:zoom="3.5803196"
-     inkscape:cx="1.5361757"
-     inkscape:cy="46.923185"
+     inkscape:cx="59.910853"
+     inkscape:cy="45.805967"
      inkscape:window-width="1312"
      inkscape:window-height="826"
      inkscape:window-x="128"
@@ -86,8 +86,12 @@
        id="rect2263"
        width="18.029238"
        height="13.229167"
-       x="49.962738"
-       y="84.165672" />
+       x="57.881454"
+       y="70.936493" />
+    <path
+       style="fill:none;stroke:#cccccc;stroke-width:1.58750005;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 49.962738,84.238378 c 17.091512,0 17.091512,0 17.091512,0"
+       id="path2281-3" />
     <rect
        style="fill:none;fill-opacity:0.0309734;stroke:none;stroke-width:1.08736;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect1973"
@@ -98,14 +102,14 @@
     <ellipse
        style="fill:#007bff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.508814;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter7716)"
        id="path31"
-       cx="58.977356"
+       cx="66.896072"
        cy="84.165657"
        rx="6.3601766"
        ry="6.3601761" />
     <circle
        style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.491369;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path6900"
-       cx="58.977356"
+       cx="66.896072"
        cy="84.165657"
        r="2.4882522" />
   </g>

--- a/docassemble/HousingCodeChecklist/data/static/done_first_item_nested.svg
+++ b/docassemble/HousingCodeChecklist/data/static/done_first_item_nested.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="34mm"
+   height="26.458334mm"
+   viewBox="0 0 34 26.458334"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1 (c4e8f9e, 2021-05-24)"
+   sodipodi:docname="done_first_item_nested.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="px"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="2.2041565"
+     inkscape:cx="53.308375"
+     inkscape:cy="-10.888519"
+     inkscape:window-width="1312"
+     inkscape:window-height="826"
+     inkscape:window-x="50"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-49.962738,-70.936493)">
+    <path
+       style="fill:none;stroke:#cccccc;stroke-width:1.58750002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 49.962738,84.16566 c 17.238664,0 17.238664,0 17.238664,0"
+       id="path2281" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.876008;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2263"
+       width="13.229167"
+       height="13.229167"
+       x="60.348156"
+       y="70.936493" />
+    <rect
+       style="fill:none;fill-opacity:0.0309734;stroke:none;stroke-width:1.08736;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1973"
+       width="13.229167"
+       height="26.458334"
+       x="49.962738"
+       y="70.936493" />
+    <circle
+       style="fill:#007bff;fill-opacity:1;fill-rule:evenodd;stroke-width:0.0677653"
+       id="path31"
+       cx="66.962738"
+       cy="84.165657"
+       r="6.6145835" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#f6f6f6;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 62.824315,84.747546 3.049152,2.447183 5.227694,-6.058119"
+       id="path925"
+       sodipodi:nodetypes="ccc" />
+  </g>
+</svg>

--- a/docassemble/HousingCodeChecklist/data/static/styles.css
+++ b/docassemble/HousingCodeChecklist/data/static/styles.css
@@ -89,8 +89,8 @@
 .danav-vertical .nav-link.active,
 .danav-vertical .show > .nav-link {
   /* To play with a thick underline, uncomment these. A little too much? Especially with 'g's */
-  /* text-decoration: underline;
-  text-decoration-thickness: 2.5px; */
+  text-decoration: underline;
+  text-decoration-thickness: 1.5px;
   background: none;
   color: #007bff;
 }

--- a/docassemble/HousingCodeChecklist/data/static/styles.css
+++ b/docassemble/HousingCodeChecklist/data/static/styles.css
@@ -26,11 +26,12 @@
 
 /* === Nav item containers === */
 .danav-vertical.danavnested {
-  padding-left: 1em;
+  margin-left: 1em;
+  padding: 0;
 }
 
 /* Vertical line for outer-most nav items */
-.danav-vertical:not(.danavnested) {
+.danav-vertical {
   border-left: 2px solid #cccccc;
   border-radius: 0;
 }
@@ -45,7 +46,7 @@
   display: inline-block;
   position: absolute;
   /* The dimensions have to be bigger than the images of the circles, though it doesn't matter how much bigger. */
-  width: 1.5em;
+  width: 2.1em;
   /* This aligns well with the text while smaller heights don't. The images can be changed so that the we can decrease the circle sizes if we want. */
   height: 2em;
   /* Account for the border that creates the vertical line. */
@@ -71,6 +72,12 @@
   /* Has extra white above the circle image to hide the border going through it. */
   background-image: url(active_first_item.svg);
 }
+/* First nested items */
+.danav-vertical .danav-vertical .danavlink.active:first-child:before,
+.danav-vertical .danav-vertical .danavlink.daclickable.active:first-child:before {
+  /* same image, but with bar extending from left to match vertical bar */
+  background-image: url(active_first_item_nested.svg);
+}
 .danav-vertical .danavlink.active:last-child:before,
 .danav-vertical .danavlink.daclickable.active:last-child:before {
   /* Has extra white below the circle image to hide the border going through it. */
@@ -81,6 +88,9 @@
 /* The color for an active item is now primay-colored text with no background. Should be handled with SCSS. Previous style was while text with primary-colored background. */
 .danav-vertical .nav-link.active,
 .danav-vertical .show > .nav-link {
+  /* To play with a thick underline, uncomment these. A little too much? Especially with 'g's */
+  /* text-decoration: underline;
+  text-decoration-thickness: 2.5px; */
   background: none;
   color: #007bff;
 }
@@ -91,6 +101,7 @@
   display: none;
 }
 
+
 /* === Completed nav items (will all look clickable) === */
 .danav-vertical .danavlink::before {
   background-image: url(done.svg);
@@ -99,10 +110,16 @@
   /* Has extra white above the circle image to hide the border going through it. */
   background-image: url(done_first_item.svg);
 }
+/* First nested items */
+.danav-vertical .danav-vertical .danavlink:first-child:before {
+  /* Same image, but with bar extending from left to match vertical bar */
+  background-image: url(done_first_item_nested.svg);
+}
 .danav-vertical .danavlink:last-child:before {
   /* Has extra white below the circle image to hide the border going through it. */
   background-image: url(done_last_item.svg);
 }
+
 
 /* === Nav items for sections that have not yet been visited. === */
 .danav-vertical .danavlink.danotavailableyet:before {
@@ -174,4 +191,3 @@
   width: 1.5em !important;
   vertical-align: middle;
 }
-

--- a/docassemble/HousingCodeChecklist/data/static/styles.css
+++ b/docassemble/HousingCodeChecklist/data/static/styles.css
@@ -100,7 +100,9 @@
 .danav-vertical .danavlink .toggler {
   display: none;
 }
-
+.daclickable:hover {
+  text-decoration: underline;
+}
 
 /* === Completed nav items (will all look clickable) === */
 .danav-vertical .danavlink::before {

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='docassemble.HousingCodeChecklist',
       url='https://madeuptcocode.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALMassachusetts>=0.1.2', 'docassemble.AssemblyLine>=2.20.1', 'docassemble.MAHousingTRO', 'docassemble.MassAccess>=0.3.0', 'docassemble.RentalRepairLetter', 'docassemble.SanitaryCode'],
+      install_requires=['docassemble.ALMassachusetts>=0.1.2', 'docassemble.AssemblyLine>=2.21.0', 'docassemble.MAHousingTRO', 'docassemble.MassAccess>=0.3.0', 'docassemble.RentalRepairLetter', 'docassemble.SanitaryCode'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/HousingCodeChecklist/', package='docassemble.HousingCodeChecklist'),
      )


### PR DESCRIPTION
Try it out and see if it fulfills the spec. You can try underlines under active items by uncommenting lines 92 and 93 in styles.css. It looked a bit busy to me, but you can play around with the thickness. It's a shame we can't do anything about the HTML as the solutions we have at our disposal are all a little fragile to future style changes.

Also, it looked like the 'active' image is a little different than what's depicted in the issue, so I assumed your designer already had a go at adjusting the glow.