### PR TITLE
Added language about non-retaliatory rent increases

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/autoterms.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/autoterms.yml
@@ -26,5 +26,13 @@ terms:
     To learn more, search for RAFT online or visit [the Mass.gov page](https://www.mass.gov/how-to/apply-for-raft-emergency-help-for-housing-costs).
   retaliation: |
     Retaliation includes evicting you or raising your rent because you complained about housing problems. Retaliation is against the law. The court can protect you from retaliation.
+    <BR>
+    <BR>
+    However, your landlord **can still raise the rent for other legitimate reasons**. 
+    It is **not retaliation** if your landlord raises the rent to:
+    
+      * Make a higher profit.
+      * Match their actual expenses for the unit.
+      * Match the current market rate of the unit.
   uninhabitable: |
     A unit is uninhabitable if the Board of Health finds that it is unsuitable for people to live in **or** it is not possible to repair the unit while tenants are still living there.

--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -1142,11 +1142,38 @@ subquestion: |
     simply because they enforced their rights to live in a safe and habitable that is up to code, that may be unlawful.
     </p>
     % endif
+    ${ collapse_template(non_retaliation_rent_raise) }
     Read more about illegal <a class="alert-link" href="https://www.masslegalhelp.org/housing-apartments-shelter/eviction/when-eviction-illegal" target="_blank" rel="noopener noreferrer">eviction</a> and <a class="alert-link" href="https://www.masslegalhelp.org/housing-apartments-shelter/rent/illegal-retaliatory-rent-increases" target="_blank" rel="noopener noreferrer">rent increases</a> on MassLegalHelp.
     </p>
   </div>
 continue button field: intro_terms_of_use  
 continue button label: Get started
+---
+template: non_retaliation_rent_raise
+subject: |
+  % if person_answering == "tenant":
+  Can my landlord still raise the rent after I try to enforce my tenant rights?
+  % else:
+  Can the landlord still raise the rent after the tenant tries to enforce their rights?
+  % endif
+content: |
+  % if person_answering == "tenant":
+  It is **not** considered retaliation if your landlord raises your rent for a reason **other** than you trying to enforce your rights.
+  
+  These reasons might include:
+  
+  * Getting a higher profit
+  * Matching their actual expenses
+  * Matching the current market rate
+  % else:
+  It is **not** considered retaliation if the landlord raises the tenant's rent for a reason **other** than the tenant trying to enforce their rights.
+  
+  These reasons might include:
+  
+  * Getting a higher profit
+  * Matching their actual expenses
+  * Matching the current market rate
+  % endif
 ---
 id: track conditions intro
 question: |


### PR DESCRIPTION
Fixed #650 

- Added language to entry for retaliation in `autoterms.yml`.
<img width="924" height="772" alt="Screenshot 2026-06-30 at 2 54 37 PM" src="https://github.com/user-attachments/assets/86d1b647-fb77-407f-8665-f5724558aba0" />

- Created collapse template about non-retaliatory rent raises (`non_retaliation_rent_raise`) and added it to screen for `intro_terms_of_use`.
<img width="942" height="858" alt="Screenshot 2026-06-30 at 2 25 36 PM" src="https://github.com/user-attachments/assets/73cf22a5-366d-4f24-8ff9-ef1186b44697" />