### PR TITLE
Added new screen with reminder to register and sign in

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
@@ -10,6 +10,19 @@ include:
 # Used in multiple templates
 ###############
 ---
+id: register prompt
+question: |
+  Remember to sign in to save your progress!
+subquestion: |
+  **Before going any further**, we strongly encourage you to **create an account** and **sign in**.
+  This will let you save your answers and return to where you left off in the interview.
+  
+  You may continue without signing in, but **you will risk losing all your progress** if you exit before finishing the interview.
+
+  **To sign in or create a new account**, open the menu in the top right corner of your screen and click **Sign in or sign up to save answers**. 
+
+continue button field: register_prompt
+---
 id: who is using this interview
 question: |
   Who are you?

--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -135,6 +135,7 @@ code: |
     intro_and_terms_of_use_in_court
   else:
     intro_and_terms_of_use
+  register_prompt
   person_answering
   users.gather()
   if person_answering == "attorney" and representation_type == "entering_appearance":


### PR DESCRIPTION
Fixed #653 
- Added new continue screen (register_prompt) immediately after the terms of use screen. The new screen prompts the user to register for an account and sign in to avoid losing their progress. It also directs them to the menu link for creating an account or signing in. 
<img width="932" height="560" alt="Screenshot 2026-06-30 at 3 54 18 PM" src="https://github.com/user-attachments/assets/a7566aeb-d41e-46e5-8046-d863df13af1f" />