### PR TITLE
Removed Chelsea email feature

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
@@ -441,7 +441,7 @@ question: |
   % if person_answering == "tenant":
   What is your address?
   % else:
-  What is ${ users.familiar() }'s address?
+  What is ${ users[0].name.first }'s address?
   % endif
 subquestion: |
   % if person_answering == "tenant":
@@ -501,7 +501,7 @@ fields:
 id: additional persons address
 generic object: Individual
 question: |
-  What is ${ users[i].familiar() }'s address?
+  What is ${ users[i].name.first }'s address?
 subquestion: |
   % if person_answering == "tenant":
   Write the address where you are having the problems you want to report.
@@ -2657,3 +2657,4 @@ question: |
   % endif
 fields:
   code: household[i].name_fields()
+---

--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -224,10 +224,7 @@ code: |
   uptocode_review
   basic_questions_signature_flow
 
-  if document_choice["get_inspection"] and users[0].address.city.lower() == "chelsea":
-    direct_inspection_email
-  else:
-    direct_inspection_email = False
+  direct_inspection_email = False
 
   reached_download_screen = True
   reconsider("snapshot_interview_state")

--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -1639,7 +1639,7 @@ subquestion: |
 fields:
   - label: <span class="visually-hidden">List problems in another room or category</span>
     field: bad_conditions.there_is_another
-    datatype: yesno
+    datatype: yesnoradio
 ---
 code: |
   # available buttons doesn't include the "short" list


### PR DESCRIPTION
Fixed #658 
- Edited conditional logic statement that controls direct_inspection_email; it will now be set to False by default. This ended up being the most straightforward way to remove the Chelsea email feature without causing other bugs.
- I further analyzed the files with Codex to make sure no other email features would be affected.

Fixed #659 
- Closing out this issue since it becomes moot once we remove the Chelsea email feature.
