### PR TITLE
Fixed address error by removing use of .familiar() from question field

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
@@ -441,7 +441,7 @@ question: |
   % if person_answering == "tenant":
   What is your address?
   % else:
-  What is ${ users.familiar() }'s address?
+  What is ${ users[0].name.first }'s address?
   % endif
 subquestion: |
   % if person_answering == "tenant":
@@ -501,7 +501,7 @@ fields:
 id: additional persons address
 generic object: Individual
 question: |
-  What is ${ users[i].familiar() }'s address?
+  What is ${ users[i].name.first }'s address?
 subquestion: |
   % if person_answering == "tenant":
   Write the address where you are having the problems you want to report.
@@ -2657,3 +2657,4 @@ question: |
   % endif
 fields:
   code: household[i].name_fields()
+---


### PR DESCRIPTION
Fixed #667 

**The bug was being triggered by the following factors:**
The interview called `users.gather()`. Users is an `ALPeopleList`, whose `complete_attribute` is "complete". `Users[i].complete` requires `users[i].address.address`. The interview then renders the heading `What is ${ users.familiar() }'s address?`. When a bogus address (e.g. using Latin filler phrases) is not accepted by the autocomplete/address machinery, Docassemble tried to ask for `users[0].address.address` again. But while rendering that same address question, `${ users.familiar() }` iterates/gathers the `users` list, which requires `users[0].complete`, which requires `users[0].address.address`, which is the same variable being asked by the interview. That caused the repeated `users[0].complete is not defined` and `users[0].address.address is not defined` messages in the traceback. 

Solution:
We can avoid this by using the already-gathered tenant name (`users[0].name.first`) directly in the question text instead of using `users.familiar()` while `users.gather()` is still incomplete.
