### PR TITLE
Replaced yesno datatype with yesnoradio

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -1639,7 +1639,7 @@ subquestion: |
 fields:
   - label: <span class="visually-hidden">List problems in another room or category</span>
     field: bad_conditions.there_is_another
-    datatype: yesno
+    datatype: yesnoradio
 ---
 code: |
   # available buttons doesn't include the "short" list


### PR DESCRIPTION
Fixed #669 

- Issue was being caused by using `yesno` datatype in the question screen `there is another condition`. This was rendering a single checkbox. Since the label was visually hidden, the user only saw a blank unlabeled checkbox.
- Fixed by replacing `yesno` with `yesnoradio`, which renders the Yes and No choices (see image below).

<img width="873" height="619" alt="Screenshot 2026-08-10 at 11 37 12 PM" src="https://github.com/user-attachments/assets/8520420e-b4a8-4c57-a58e-469d7e47bcac" />