### PR TITLE
Gather the variables document assembly needs before it starts

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
@@ -576,7 +576,7 @@ fields:
     field: users[i].has_separate_mailing_address
     datatype: yesno
 validation code: |
-  if not defined("users[i].has_separate_mailing_address"):
+  if not users[i].has_separate_mailing_address:
     users[i].mailing_address = users[i].address
 ---
 id: additional tenant mailing address

--- a/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/customized_screens.yml
@@ -507,7 +507,7 @@ question: |
   % if person_answering == "tenant":
   What is your mailing address?
   % else:
-  What is ${ users.familiar() }'s mailing address?
+  What is ${ users[0].familiar() }'s mailing address?
   % endif
 fields:
   - ${ users[0].address.address_label}: users[0].mailing_address.address
@@ -520,10 +520,7 @@ fields:
       states_list(country_code=AL_DEFAULT_COUNTRY)
     default: ${ AL_DEFAULT_STATE }
   - ${ users[0].address.zip_label}: users[0].mailing_address.zip
-    required: False      
-  - ${ users[0].address.country_label}: users[0].mailing_address.country
-    code: countries_list()
-    default: ${ AL_DEFAULT_COUNTRY }
+    required: False
 ---
 id: additional persons address
 generic object: Individual
@@ -550,7 +547,16 @@ fields:
       lambda y: y.on_one_line()      
     none of the above: |
       Somewhere else
-    disable others: True
+    # Only the street address fields. `disable others: True` would also lock
+    # the mailing address checkbox below, which both hides the question from
+    # tenants who live together but get mail separately and leaves
+    # users[i].has_separate_mailing_address undefined for the validation code.
+    disable others:
+      - users[i].address.address
+      - users[i].address.unit
+      - users[i].address.city
+      - users[i].address.state
+      - users[i].address.zip
     show if:
       code: |
         defined("users[0].address.address")
@@ -581,11 +587,7 @@ validation code: |
 ---
 id: additional tenant mailing address
 question: |
-  % if person_answering == "tenant":
-  What is your mailing address?
-  % else:
   What is ${ users[i].familiar() }'s mailing address?
-  % endif
 fields:
   - ${ users[i].address.address_label}: users[i].mailing_address.address
     address autocomplete: True
@@ -597,10 +599,7 @@ fields:
       states_list(country_code=AL_DEFAULT_COUNTRY)
     default: ${ AL_DEFAULT_STATE }
   - ${ users[i].address.zip_label}: users[i].mailing_address.zip
-    required: False      
-  - ${ users[i].address.country_label}: users[i].mailing_address.country
-    code: countries_list()
-    default: ${ AL_DEFAULT_COUNTRY }
+    required: False
 ---
 id: attorneys name
 question: |

--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -138,6 +138,12 @@ code: |
   register_prompt
   person_answering
   users.gather()
+  # The address screen only offers a "separate mailing address" checkbox.
+  # Nothing else asks for the mailing address itself, so ask for it here.
+  # Otherwise it stays undefined until a template needs it, which is during
+  # background assembly, where the question cannot be asked.
+  for user in users.complete_elements():
+    user.mailing_address.address
   if person_answering == "attorney" and representation_type == "entering_appearance":
     users[0].attorney.target_number = 1
     users[0].attorney.name.first

--- a/docassemble/HousingCodeChecklist/data/questions/verified_complaint_and_motions_to_include.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/verified_complaint_and_motions_to_include.yml
@@ -66,6 +66,10 @@ code: |
   trial_court.address.address
   if complaint_ask_for_damages:
     interview_order_discovery
+  else:
+    # discovery_attachment.enabled reads wants_discovery unconditionally, so
+    # it has to be defined even on the branches that never offer discovery.
+    wants_discovery = False
   signature_date
   claim_jurytrial
   verified_complaint_wants_fee_waiver


### PR DESCRIPTION
Two variables the document templates need are never gathered by the interview
order. Because they are first demanded during background assembly, where no
question can be asked, the assembly task dies. The tenant then gets a stray
question *after* the "please wait while we make your documents" screen, and the
download screen has to assemble that bundle synchronously instead.

Closes #646

### The mailing address

The address screens offer an "I have another address where I get mail"
checkbox, but nothing in the interview order ever asks for that address. The
validation code only copies the street address into `mailing_address` when the
box is left *unchecked*, so a tenant who checks it leaves
`users[0].mailing_address` undefined for the rest of the interview.

`Evidence_packet.docx` renders `users[0].mailing_address.block()`, so the
variable is first demanded during assembly:

```
NameError exception during document assembly: name 'users[0].mailing_address.address' is not defined
```

Now asked right after `users.gather()`.

The additional-tenant screen had a related bug: its validation code tested
`defined("users[i].has_separate_mailing_address")` rather than the value of the
checkbox. Since a `yesno` field is always defined once answered, that branch
never ran, so additional tenants never had `mailing_address` copied from
`address` at all.

### wants_discovery

`interview_order_verified_complaint_and_motions` only runs
`interview_order_discovery` when the tenant asks for money damages, but
`discovery_attachment.enabled` reads `wants_discovery` unconditionally:

```python
discovery_attachment.enabled = verified_complaint_attachment.enabled and wants_discovery
```

A tenant who sues for repairs without asking for damages therefore leaves
`wants_discovery` undefined. The first thing to touch it is
`affirmative_complaint_bundle`'s background assembly task, so that task dies and
the whole court bundle — complaint, motions, proposed orders, affidavit — is
assembled synchronously on the download screen. The tenant also gets a stray
"Proving your case" question after the waiting screen.

### From the testing round (commit 2)

Testing this branch turned up three more problems on the same screens.

**Choosing "Same as your address" for a second tenant errored out** with
`name 'users[1].has_separate_mailing_address' is not defined`, and the
"… has another address where they get mail" checkbox was greyed out. The
`disable others: True` on the "same as" radio disables *every* other field on
the screen, including that checkbox, so it was never submitted and the
validation code above raised on it. It also meant tenants who live together but
get mail separately had no way to say so. `disable others` now names the five
address fields instead.

**The mailing address screen for an additional tenant asked "What is _your_
mailing address?"**, so a tenant filling in three mailing addresses in a row had
no way to tell whose was whose. It now names the person. The first tenant's
screen interpolated `users.familiar()`, which lists every tenant, rather than
`users[0].familiar()`.

**Both mailing address screens offered a country dropdown next to a list of US
states**, so a tenant could file a mailing address in "Minnesota, Latvia". The
property address screen has no country field and neither does AssemblyLine's own
address question; these now match. Worth a second opinion: this does mean a
mailing address outside the US can no longer be entered.

### Reviewed, no change needed

Two more items in the testing report are about the same screens, and both turned
out to be the intended behaviour. Writing them down here so the next person to
read the report does not go looking for a bug.

**"Mailing address shows as a single line. Unsure if this is intended."** Yes.
The signature block prints the property address as a block and then labels the
mailing address on one line, and only when the two differ:

```
{% if user.mailing_address == user.address %}{{ user.mailing_address.block() }}{% else %}{{ user.address.block() }}
Mailing address: {{ user.mailing_address.on_one_line() }}{% endif %}
```

That is in `verified_complaint.docx`, `motion_for_injunctive_relief.docx`,
`discovery.docx` and `motion_to_compel_discovery.docx`, and in the two Spanish
templates as *Dirección postal*.

**"Up to code documents only show mailing address."** Also intended, for
letters. `letter_to_request_inspection.docx` uses the mailing address as the
sender's return address, which is where the inspector should write back — and
when it differs from the property address the letter says so in the body and
gives the address to inspect:

```
{%p if users[0].mailing_address != users[0].address %}
We are not currently staying at the home we rent. The address that we want you to inspect is:
{{ users[0].address.on_one_line() }}
{%p endif %}
```

Both of these only became visible once this PR started asking for a mailing
address that can actually differ from the property address. Before it, the two
were always the same object, so the `if` branches never ran.

### In this PR, I have:

* [X] Manually tested to ensure my PR is working
* [X] Ensured issues that this PR closes will be automatically closed
* [ ] Requested a review

### Testing

Installed on a local docassemble instance with `dainstall .` and driven end to
end through the JSON API on all three entry paths ("Get help in court", "Start
your list", and the give-notice path). Before this change the court path showed
a mailing-address question and a "Proving your case" question after the waiting
screen; after it, all three paths go straight from the waiting screen to the
download screen with no stray questions.

Commit 2 was driven through a real browser with Playwright, because the bug only
happens with fields that JavaScript disables. Before the change, picking "Same
as your address" for a second tenant reproduced the error banner in the issue
exactly; after it the screen submits, and a second tenant who ticks the mailing
address box gets their own "What is Clare's mailing address?" screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


