### PR TITLE
Let the tenant choose which documents to make and email

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -258,6 +258,11 @@ code: |
   ):
     bundles_to_assemble.append(affirmative_complaint_bundle)
 
+  # Let the tenant drop documents they do not want before we spend time
+  # assembling them.
+  if len(selectable_documents) > 1:
+    document_selection_applied
+
   assembly_started_at
 
   # Assemble one bundle at a time. Starting every task in the same request
@@ -3076,7 +3081,9 @@ code: |
 ---
 code: |
   organize_tenants_attachment.enabled = (
-    screen_ll_knows_problem and document_choice["organize_tenants"]
+    screen_ll_knows_problem
+    and document_choice["organize_tenants"]
+    and include_document.get("organize_tenants_attachment", True)
   )
 ---
 code: |
@@ -3086,6 +3093,7 @@ code: |
       screen_ll_knows_problem
       and document_choice["get_report"]
       and include_conditions_in_complaint
+      and include_document.get("conditions_report_attachment", True)
     )
     or direct_inspection_email
   )
@@ -3094,38 +3102,49 @@ code: |
   request_housing_inspection_attachment.enabled = (
     screen_ll_knows_problem
     and document_choice["get_inspection"]
+    and include_document.get("request_housing_inspection_attachment", True)
     or direct_inspection_email
   )
 ---
 code: |
   tenant_repair_request_attachment.enabled = (
     not screen_ll_knows_problem or document_choice["tell_landlord"]
-  )
+  ) and include_document.get("tenant_repair_request_attachment", True)
 ---
 code: |
   letter_to_notify_landlord_instructions_attachment.enabled = (
     not screen_ll_knows_problem or document_choice["tell_landlord"]
-  )
+  ) and include_document.get("letter_to_notify_landlord_instructions_attachment", True)
 ---
 code: |  
   Repair_Demand_Letter_attachment.enabled = (
-    screen_ll_knows_problem and document_choice["demand_letter_93a"]
+    screen_ll_knows_problem
+    and document_choice["demand_letter_93a"]
+    and include_document.get("Repair_Demand_Letter_attachment", True)
   )
 ---
 code: |
   Repair_Demand_Letter_post_interview_instructions.enabled = (
-    screen_ll_knows_problem and document_choice["demand_letter_93a"]
+    screen_ll_knows_problem
+    and document_choice["demand_letter_93a"]
+    and include_document.get("Repair_Demand_Letter_post_interview_instructions", True)
   )
 ---
 code: |
-  verified_complaint_attachment.enabled = document_choice["sue_landlord"]
+  verified_complaint_attachment.enabled = document_choice[
+    "sue_landlord"
+  ] and include_document.get("verified_complaint_attachment", True)
 ---
 code: |
-  next_steps_for_court_attachment.enabled = document_choice["sue_landlord"]
+  next_steps_for_court_attachment.enabled = document_choice[
+    "sue_landlord"
+  ] and include_document.get("next_steps_for_court_attachment", True)
 ---
 code: |
   verified_complaint_attachment.enabled = (
-    screen_ll_knows_problem and document_choice["sue_landlord"]
+    screen_ll_knows_problem
+    and document_choice["sue_landlord"]
+    and include_document.get("verified_complaint_attachment", True)
   )
 ---
 code: |  
@@ -3145,7 +3164,9 @@ code: |
 ---
 code: |
   contempt_complaint.enabled = (
-    screen_ll_knows_problem and document_choice["contempt_complaint"]
+    screen_ll_knows_problem
+    and document_choice["contempt_complaint"]
+    and include_document.get("contempt_complaint", True)
   )
 ---
 objects:
@@ -3272,6 +3293,89 @@ objects:
       ], title="Documents for future case use",
       filename="further_documents",
       )
+---
+############### Letting the tenant pick documents ###############
+---
+objects:
+  # Keyed by document instanceName. Every `.enabled` block consults this with
+  # a default of True, so an empty dict means "make everything", and the
+  # bundles behave exactly as they did before the tenant reaches the picker.
+  - include_document: DADict.using(auto_gather=False, gathered=True)
+---
+code: |
+  # The documents a tenant can turn off. Companion documents follow their main
+  # document instead of appearing separately: the proposed orders and the
+  # motion for injunctive relief go with the verified complaint, the motion to
+  # compel goes with discovery, and each Spanish translation goes with its
+  # English original.
+  selectable_documents = [
+    document
+    for document in [
+      conditions_report_attachment,
+      tenant_repair_request_attachment,
+      letter_to_notify_landlord_instructions_attachment,
+      request_housing_inspection_attachment,
+      Repair_Demand_Letter_attachment,
+      Repair_Demand_Letter_post_interview_instructions,
+      verified_complaint_attachment,
+      next_steps_for_court_attachment,
+      contempt_complaint,
+      discovery_attachment,
+      organize_tenants_attachment,
+    ]
+    if document.enabled
+  ]
+---
+code: |
+  selectable_document_choices = [
+    {document.instanceName: str(document.title)} for document in selectable_documents
+  ]
+---
+code: |
+  for document in selectable_documents:
+    include_document[document.instanceName] = documents_to_include[
+      document.instanceName
+    ]
+    # Building the list of choices already evaluated `enabled`, back when the
+    # gate was empty and everything looked enabled. ALDocument.is_enabled()
+    # reuses that stored value rather than recomputing, so throw it away and
+    # let the gate we just set decide.
+    undefine(document.instanceName + ".enabled")
+  document_selection_applied = True
+---
+id: choose documents
+question: |
+  % if person_answering == "tenant":
+  Which documents do you want?
+  % else:
+  Which documents does the tenant want?
+  % endif
+subquestion: |
+  % if person_answering == "tenant":
+  We can make all of these for you. Uncheck anything you do not need, and we
+  will leave it out of your downloads and out of the email we send you.
+  % else:
+  We can make all of these. Uncheck anything the tenant does not need, and we
+  will leave it out of the downloads and out of the email.
+  % endif
+fields:
+  # This has to be a variable of its own. If the question set
+  # include_document directly, then asking it would be one of the ways
+  # docassemble could define include_document, and working out the choices
+  # reads every document's `enabled`, which reads include_document: an
+  # infinite loop.
+  - no label: documents_to_include
+    datatype: checkboxes
+    code: |
+      selectable_document_choices
+    default:
+      code: |
+        [document.instanceName for document in selectable_documents]
+    none of the above: False
+    minlength: 1
+    validation messages:
+      minlength: |
+        Keep at least one document.
 ---
 objects:
   - lsc_logo: DAStaticFile.using(filename="lsc_logo_horizontal.jpg")

--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -3372,10 +3372,16 @@ fields:
       code: |
         [document.instanceName for document in selectable_documents]
     none of the above: False
-    minlength: 1
-    validation messages:
-      minlength: |
-        Keep at least one document.
+    # Not `required` / `minlength`, which draw a red asterisk beside the first
+    # checkbox: testers read that as "the first document is mandatory" and then
+    # found they could uncheck it anyway. The rule is about the list as a
+    # whole, so it belongs in the validation code.
+    required: False
+validation code: |
+  if not any(documents_to_include.values()):
+    validation_error(
+      "Keep at least one document.", field="documents_to_include"
+    )
 ---
 objects:
   - lsc_logo: DAStaticFile.using(filename="lsc_logo_horizontal.jpg")

--- a/docassemble/HousingCodeChecklist/data/questions/verified_complaint_and_motions_to_include.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/verified_complaint_and_motions_to_include.yml
@@ -106,7 +106,11 @@ code: |
   verified_complaint_claims.gathered = True
 ---
 code: |
-  discovery_attachment.enabled = verified_complaint_attachment.enabled and wants_discovery
+  discovery_attachment.enabled = (
+    verified_complaint_attachment.enabled
+    and wants_discovery
+    and include_document.get("discovery_attachment", True)
+  )
 ---
 code: |
   motion_to_compel_discovery_attachment.enabled = discovery_attachment.enabled
@@ -116,7 +120,9 @@ code: |
 ---
 code: |
   affidavitofindigency_attachment.enabled = (
-    document_choice["sue_landlord"]
+    # The affidavit is filed with the complaint, so it follows the complaint
+    # rather than document_choice["sue_landlord"] on its own.
+    verified_complaint_attachment.enabled
     and verified_complaint_wants_fee_waiver == "wants_fee_waiver"
     and is_indigent
   )


### PR DESCRIPTION
> **Stacked on #672** (which is stacked on #671). Base is `656-generation-speed`,
> so the diff here is just the one commit below.

Closes #651

The interview can produce a dozen documents at once — a conditions report,
letters, next-steps instructions, a verified complaint with four proposed
orders, discovery — which users told us is overwhelming.

This adds a **"Which documents do you want?"** screen just before assembly. It
lists every document the tenant's answers would produce, with all of them
checked, and unchecking one keeps it out of both the downloads and the emailed
copy. The screen is skipped when there is only one document to choose from.

Companion documents follow their main document rather than cluttering the list:

| main document | follows it |
|---|---|
| verified complaint | motion for injunctive relief, temporary order, simple temporary order, preliminary injunction, simple preliminary injunction, order of notice, affidavit of indigency |
| discovery | motion to compel discovery |
| any English document | its Spanish translation |
| inspection request | next steps for the inspection request |

The affidavit of indigency previously keyed off `document_choice["sue_landlord"]`
on its own; it now follows `verified_complaint_attachment.enabled`, since it is
filed with the complaint and should not survive on its own if the tenant drops
the complaint.

### Two things worth knowing about the implementation

**The question sets its own variable rather than writing `include_document`
directly.** Working out the choices reads every document's `enabled`, which
reads `include_document`, so a question that *defined* `include_document` would
be an infinite loop — docassemble reports it as:

```
DASourceError: There appears to be an infinite loop.
Variables in stack are include_document, selectable_document_choices, selectable_documents, x.enabled.
```

**Applying the selection also has to undefine each document's `enabled`.**
Working out the choices already evaluated it, back when the gate was empty and
everything looked enabled, and `ALDocument.is_enabled()` reuses that stored
value instead of recomputing. Without the `undefine()` the first assembly runs
with stale flags and the unchecked documents still appear.

The gate is a `DADict` read with a default of `True`, so any document whose
`enabled` block has not been gated, and any session that never reaches the
screen, behaves exactly as before.

### From the testing round (commit 2)

A tester running as an attorney reported a red asterisk beside "Housing
Conditions Report" that was not enforced: they unchecked it and continued
anyway.

The asterisk came from `minlength: 1`. docassemble draws the required marker in
the label column, and with `no label` that puts it right next to the first
checkbox, where it reads as "this document is mandatory". The rule is about the
list as a whole rather than any one document, so it moves into validation code
and the field-level marker goes away. Unchecking everything still stops with
"Keep at least one document."

### In this PR, I have:

* [X] Manually tested to ensure my PR is working
* [X] Ensured issues that this PR closes will be automatically closed
* [ ] Requested a review

### Testing

Installed with `dainstall .` and driven end to end through the JSON API, both
ways round:

* **everything left checked** — the court path produces the identical
  11-document set it did before this change
* **complaint unchecked** — the complaint, all four proposed orders, the motion
  for injunctive relief and the affidavit of indigency all disappear from the
  download list and from the "all documents for your records" email bundle,
  leaving only the documents that were kept

Also run on the give-notice and start-your-list paths, and in Spanish.

Commit 2 was driven through a real browser with Playwright: the picker screen
now has no asterisk anywhere on it, submitting with everything unchecked comes
back with "Keep at least one document.", and unchecking Discovery drops both
Discovery and Motion to Compel Discovery from the download screen while the
complaint and its companion documents stay.

The issue also asks whether some document variants can be dropped altogether.
That is a content decision rather than a code one, so it is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

