### PR TITLE
Record the interview language the tenant actually chose

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -106,15 +106,8 @@ default screen parts:
     <img src="${ uptocode_logo.url_for() }"><div class="title"></div>
   short logo: |
     <img src="${ uptocode_logo.url_for() }"><div class="title"></div>
-  # commenting out until we have translations
-  #navigation bar html: |
-    #% if defined('acknowledged_information_use'):
-    #${ get_language_list(get_tuples(['en','es','pt','ht']),current=user_language) }
-    #% endif
----
-# setting user language to English until we have translations
-code: |
-  user_language = "en"
+  # The language switcher comes from AssemblyLine's al_language.yml, driven by
+  # al_interview_languages in language.yml. Do not add one here.
 ---
 code: |
   # Allow downloads on the custom error screen
@@ -713,7 +706,7 @@ code: |
     "start_time": str(start_time().format("yyyy-MM-dd")),
     "address_city": showifdef("users[0].address.city"),
     "zip": showifdef("users[0].address.zip"),
-    "language": user_language,
+    "language": al_user_language,
   }
   try:
     stuff_to_snapshot["document_choice"] = comma_list(document_choice.true_values())
@@ -1499,7 +1492,7 @@ code: |
   set_gathered = True
 ---
 depends on:
-  - user_language
+  - al_user_language
 language: en
 variable name: available_buttons
 data:

--- a/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/housing_code_interview.yml
@@ -106,8 +106,21 @@ default screen parts:
     <img src="${ uptocode_logo.url_for() }"><div class="title"></div>
   short logo: |
     <img src="${ uptocode_logo.url_for() }"><div class="title"></div>
-  # The language switcher comes from AssemblyLine's al_language.yml, driven by
-  # al_interview_languages in language.yml. Do not add one here.
+  # AssemblyLine's own switcher (al_language.yml) fires `al_change_language`,
+  # which records the choice in `session_local` and leaves `al_user_language`
+  # alone. Everything in this interview that varies by language reads
+  # `al_user_language`: the housing code condition lists, the Spanish
+  # documents, the room buttons, and the analytics snapshot. Worse,
+  # `session_local` does not exist in the celery workers that assemble the
+  # documents. So use the event that sets the interview variable instead.
+  navigation bar html: |
+    % if enable_al_language and len(al_interview_languages) > 1:
+    ${ get_language_list_dropdown(
+         al_interview_languages,
+         current=al_user_language,
+         event_name="al_get_language_list_change_language",
+       ) }
+    % endif
 ---
 code: |
   # Allow downloads on the custom error screen


### PR DESCRIPTION
> Independent of #671 / #672 / #673 — branches off `main` and merges cleanly
> alongside them.

Part of #652

### What I verified

Spanish is already working in the interview, contrary to what the code comments
suggest:

* the language switcher renders in the nav bar in both languages (it comes from
  AssemblyLine's `al_language.yml`, driven by `al_interview_languages` in
  `language.yml`) — though see commit 2 below, it was wired to the wrong event
* starting a session with `?lang=es` really does run the interview in Spanish
* the Spanish **Next Steps** documents assemble and appear on the download
  screen — a Spanish court run produces "Tus próximos pasos en corte" alongside
  "Demanda verificada" and "Moción para alivio cautelar"

I could not reproduce #508 (menu disappearing in a non-English language) on the
landing page: the nav menu has the same items in both languages, with only the
language link itself swapping.

### What was broken

`user_language` was hard-coded to `"en"` by a code block whose comment said
*"setting user language to English until we have translations"*. The
translations arrived; `user_language` never caught up.

It is what the interview reports to `store_variables_snapshot` as `"language"`,
so **every session has been logged as English** and the analytics cannot show
that anyone uses the Spanish version at all.

This PR reports `al_user_language` instead, and drops the hard-coded variable
along with the commented-out language menu it fed, which AssemblyLine's own
switcher has replaced.

### From the testing round (commit 2)

Testing found that switching to Spanish part way through an interview translated
the question text but left the housing code condition lists in English, and that
a Spanish session still produced English documents. Both screenshots in the
report are reproducible.

The switcher AssemblyLine renders fires `al_change_language`, which records the
choice in `session_local` and calls `set_language()`. That covers everything
Mako renders, which is why the headings translate — but it never touches
`al_user_language`, and `al_user_language` is what this interview reads whenever
it has to *pick* a language:

* `conditions_from_list` / `conditions_with_help` choose between the
  `Interview description` and `Description_ES` columns of
  `housing_code_checklist.xlsx`
* every `*_attachment_es.enabled` block tests `al_user_language == "es"`
* the room buttons and section names in `language.yml` `depends on` it
* `snapshot_interview_state` reports it as the session's language — the very
  thing commit 1 fixes

`session_local` is also per-browser-session, so it is empty inside the celery
workers that assemble the documents, which is exactly where the Spanish
documents decide whether to render.

AssemblyLine ships a second event, `al_get_language_list_change_language`, that
sets the interview variable instead. Commit 2 overrides `navigation bar html` to
point the switcher at that one. Same menu, same markup — only the event changes.

### Still open on #652: the translation workbook is stale

Testing also flagged screens that stay in English even when the interview is
started with `?lang=es` — the "Remember to sign in" screen, "What is your
address?", the landlord questions, the new document picker.

That is not this bug. `housing_code_interview_es.xlsx` has 2,295 rows and every
one of them is translated, but docassemble matches a translation to its source
by the exact English string, and roughly **90 blocks have since been edited or
added** — about 33 in `housing_code_interview.yml` and 24 in
`customized_screens.yml`. Those screens have no matching row any more, so they
fall back to English.

Fixing that means a regenerated workbook and a translator pass, so it belongs
with the rest of #652 rather than here. Worth knowing: ALDashboard's
translation-file generator currently raises on docassemble 1.10 — it calls
`interview_source.get_interview()`, which no longer exists.

### Still open on #652

Publishing the Spanish overview page on uptocode.org is a website task outside
this repo, so it is not covered here. I'd suggest leaving #652 open for that
piece, which is why this PR says "Part of" rather than "Closes".

### In this PR, I have:

* [X] Manually tested to ensure my PR is working
* [ ] Ensured issues that this PR closes will be automatically closed — deliberately not closing #652, see above
* [ ] Requested a review

### Testing

Installed with `dainstall .` and driven end to end through the JSON API in
Spanish (switching language via the `al_get_language_list_change_language`
action). Confirmed `al_user_language` is `es`, the snapshot now records `es`
rather than `en`, and the Spanish documents still assemble.

Commit 2 was driven through a real browser with Playwright, since the bug is in
what the nav bar link does. Two runs of the court path, one clicking the
language menu at the condition list and one clicking it at the review screen:

| | before | after |
|---|---|---|
| condition list after switching | English | Spanish |
| documents after switching | English only | plus "Demanda verificada", "Moción para alivio cautelar", "Tus próximos pasos en corte" |

Also checked what the report calls "answers deleted when switching to Spanish":
only text typed on the current screen and not yet submitted is lost, which is
what any link away from a form does. Answers already submitted survive the
switch — after switching, the interview still knew about the first tenant and
went on to ask for the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

