### PR TITLE
Fix the "Use my previous answers" dead end

### DIFF
--- a/docassemble/HousingCodeChecklist/data/questions/load_answers.yml
+++ b/docassemble/HousingCodeChecklist/data/questions/load_answers.yml
@@ -45,18 +45,30 @@ objects:
   - uptocode_logo: DAStaticFile.using(filename="horiztonal-white1.5x_blue.svg")
 ---
 code: |
+  # Sessions are stored under the interview's full path. `package:file.yml`
+  # works in a URL because docassemble expands it, but the session table is
+  # matched on the stored string, so the short form never found anything and
+  # this screen always came up empty.
+  main_interview_filename = (
+    f"{user_info().package}:data/questions/housing_code_interview.yml"
+  )
+---
+code: |
   answers = get_saved_interview_list(
-    filename=f"{user_info().package}:housing_code_interview.yml",
+    filename=main_interview_filename,
     exclude_newly_started_sessions=True,
   )
-  first_answer = dict(next(iter(answers)))
 ---
+# Mandatory, because the question below is mandatory too: without this, the
+# question fired first and nothing ever ran the "only one session, go straight
+# to it" shortcut.
+mandatory: True
 code: |
   if len(answers) == 1:
     response(
       url=interview_url(
-        i=f"{user_info().package}:housing_code_interview.yml",
-        session=first_answer.get("key"),
+        i=main_interview_filename,
+        session=dict(next(iter(answers))).get("key"),
       )
     )
   load_answers
@@ -65,8 +77,30 @@ id: load saved UpToCode session
 mandatory: True
 event: load_answers
 question: |
+  % if len(answers):
   Keep working on an UpToCode session
+  % elif not user_logged_in():
+  Sign in to pick up where you left off
+  % else:
+  We could not find any saved answers
+  % endif
 subquestion: |
+  % if len(answers):
   Choose a session to keep working on below.
 
-  ${ session_list_html(filename=f"{user_info().package}:housing_code_interview.yml", show_title=False, exclude_newly_started_sessions=True)}
+  ${ session_list_html(filename=main_interview_filename, show_title=False, exclude_newly_started_sessions=True)}
+  % elif not user_logged_in():
+  We can only find your earlier answers once you are signed in.
+
+  [Sign in or create an account](${ url_of('login', next=interview_url()) }), then
+  come back to this page.
+
+  If you never signed in, your earlier answers were not saved and you will need
+  to start again.
+  % else:
+  There are no saved UpToCode sessions on your account.
+  % endif
+buttons:
+  - Start a new UpToCode session: exit
+    url: |
+      ${ interview_url(i=main_interview_filename, reset=1) }


### PR DESCRIPTION
> Independent of #671 / #672 / #673 / #674 — branches off `main` and touches
> only `load_answers.yml`.

From the testing round: *"Use my previous answers takes me to blank screen with
no option to move forward."*

The "Keep working" card on the landing page goes to `load_answers.yml`. Three
separate things were wrong with it.

### The session lookup used a filename that can never match

```python
get_saved_interview_list(filename=f"{user_info().package}:housing_code_interview.yml", ...)
```

docassemble expands `package:file.yml` when it appears in a URL, but sessions
are stored under what it expands *to*, and AssemblyLine's session query matches
on the stored string:

```sql
AND (userdict.filename = :filename OR :filename is null)
```

```
$ psql -d docassemble -c "select distinct filename from userdict where filename like '%HousingCode%'"
 docassemble.HousingCodeChecklist:data/questions/housing_code_interview.yml
 docassemble.HousingCodeChecklist:data/questions/load_answers.yml
```

So both `get_saved_interview_list` and the `session_list_html` on the screen
always came back empty, for everyone, always. The filename is now built once as
`main_interview_filename` and used in all three places.

### It cannot work at all for a visitor who is not signed in

`get_saved_interview_list` bails out early:

```python
if user_id is None:
    if user_logged_in():
        user_id = user_info().id
    else:
        log("Asked to get interview list for user that is not logged in")
        return []
```

The landing page shows the "Keep working" card to everyone, so for an anonymous
visitor this screen could only ever be empty. It now says so and offers a
sign-in link, rather than rendering a heading over nothing.

### The "only one session" shortcut was unreachable

```yaml
code: |
  if len(answers) == 1:
    response(url=interview_url(..., session=first_answer.get("key")))
  load_answers
---
id: load saved UpToCode session
mandatory: True
event: load_answers
```

The code block is not mandatory, and the question below it answers the same
`load_answers` event, so the question always fired first and the redirect never
ran. (Had it ever run with no saved sessions, `next(iter(answers))` would have
raised `StopIteration`.) The code block is now mandatory, so it runs first.

Finally, the screen gets a **Start a new UpToCode session** button, so none of
these states is a dead end.

### Reviewed, no change needed

The testing report has one more navigation item, which is not this bug:

> Going backwards holds selected choices for prior page. Going forwards does not
> remember previous selections. Also found that using forward page advanced the
> number in URL but did not actually move you to next page.

That is the browser's own Back and Forward buttons against docassemble's
hash-based history (, , …). docassemble replays a screen from
the saved answers when you go back, but Forward only changes the fragment; there
is no "next" state to restore, because the next screen depends on answers the
interview has not been given yet. Nothing in this package controls it, and the
supported way back is the **Undo** link on each screen and the section
navigation in the sidebar.

### In this PR, I have:

* [X] Manually tested to ensure my PR is working
* [ ] Ensured issues that this PR closes will be automatically closed — no issue
  filed for this one; it came out of the testing round
* [ ] Requested a review

### Testing

Installed with `dainstall .` and driven through a real browser with Playwright,
in all three states:

| | before | after |
|---|---|---|
| signed out | heading with an empty list, no way forward | "Sign in to pick up where you left off", with a sign-in link and a "Start a new UpToCode session" button |
| signed in, one saved session | heading with an empty list | redirects straight into that session |
| signed in, two saved sessions | heading with an empty list | both sessions listed, with Rename / Delete |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

